### PR TITLE
Add consolidated sections extractor

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,1 +1,24 @@
-#hello world 
+from pathlib import Path
+
+from sections import find_consolidated_sections
+
+
+PDF_PATHS = [
+    Path("/mnt/data/DFP - 2024.pdf"),
+    Path("/mnt/data/ITR 1T25.pdf"),
+]
+
+
+def main() -> None:
+    for pdf_path in PDF_PATHS:
+        print(pdf_path)
+        if not pdf_path.exists():
+            print("Arquivo não encontrado.")
+            continue
+
+        sections = find_consolidated_sections(str(pdf_path))
+        print(sections)
+
+
+if __name__ == "__main__":
+    main()

--- a/sections.py
+++ b/sections.py
@@ -1,0 +1,71 @@
+"""Module for locating consolidated financial statement sections in PDFs."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+import fitz  # PyMuPDF
+
+
+@dataclass
+class SectionMatch:
+    key: str
+    start_page: int
+    end_page: Optional[int] = None
+
+    def to_dict(self) -> Dict[str, int]:
+        end_page = self.end_page if self.end_page is not None else self.start_page
+        return {"key": self.key, "start_page": self.start_page, "end_page": end_page}
+
+
+PATTERN_MAP: Dict[str, List[str]] = {
+    "BPA": [r"DFs\s+Consolidadas\s*/\s*Balanço\s+Patrimonial\s+Ativo"],
+    "BPP": [r"DFs\s+Consolidadas\s*/\s*Balanço\s+Patrimonial\s+Passivo"],
+    "DRE": [r"DFs\s+Consolidadas\s*/\s*Demonstração\s+do\s+Resultado(?!\s+Abrangente)"],
+    "DRA": [r"DFs\s+Consolidadas\s*/\s*Demonstração\s+do\s+Resultado\s+Abrangente"],
+    "DFC": [r"DFs\s+Consolidadas\s*/\s*Demonstração\s+do\s+Fluxo\s+de\s+Caixa"],
+    "DMPL": [
+        r"DFs\s+Consolidadas\s*/\s*Demonstraç(?:ão|ões)\s+das\s+Mutações\s+do\s+Patrimônio\s+Líquido",
+        r"DFs\s+Consolidadas\s*/\s*DMPL",
+    ],
+    "DVA": [r"DFs\s+Consolidadas\s*/\s*Demonstração\s+de\s+Valor\s+Adicionado"],
+}
+
+
+def _first_pattern_match(text: str, patterns: Iterable[str]) -> bool:
+    for pattern in patterns:
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            return True
+    return False
+
+
+def find_consolidated_sections(pdf_path: str, *, max_pages: int = 40) -> Dict[str, Dict[str, int]]:
+    doc = fitz.open(pdf_path)
+    try:
+        total_pages = doc.page_count
+        search_limit = min(max_pages, total_pages)
+        matches: Dict[str, SectionMatch] = {}
+
+        for page_index in range(search_limit):
+            page = doc.load_page(page_index)
+            text = page.get_text("text")
+
+            for key, patterns in PATTERN_MAP.items():
+                if key in matches:
+                    continue
+                if _first_pattern_match(text, patterns):
+                    matches[key] = SectionMatch(key=key, start_page=page_index + 1)
+
+        if not matches:
+            return {}
+
+        ordered = sorted(matches.values(), key=lambda item: item.start_page)
+        for current, nxt in zip(ordered, ordered[1:]):
+            current.end_page = max(current.start_page, nxt.start_page - 1)
+
+        ordered[-1].end_page = total_pages
+
+        return {match.key: match.to_dict() for match in ordered}
+    finally:
+        doc.close()


### PR DESCRIPTION
## Summary
- add a sections module that scans the first pages of a PDF to locate consolidated financial statements by header
- expose a helper in main.py that runs the detector for the expected DFP and ITR documents and prints the resulting ranges

## Testing
- python main.py

------
https://chatgpt.com/codex/tasks/task_e_68d4b129e9408325a533d8dff3998607